### PR TITLE
Fix shared_datadir not being copied to a temp location

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,10 @@
-pytest-datadir 1.0.1
-====================
+pytest-datadir
+==============
 
-Fixes
------
+1.0.1 (2017-08-15)
+------------------
+
+**Fixes**
 
 - Fixed ``shared_datadir`` contents not being copied to a temp location on each test. `#12
   <https://github.com/gabrielcnr/pytest-datadir/issues/12>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,8 @@
+pytest-datadir 1.0.1
+====================
+
+Fixes
+-----
+
+- Fixed ``shared_datadir`` contents not being copied to a temp location on each test. `#12
+  <https://github.com/gabrielcnr/pytest-datadir/issues/12>`_

--- a/pytest_datadir/plugin.py
+++ b/pytest_datadir/plugin.py
@@ -6,8 +6,11 @@ import pytest
 
 
 @pytest.fixture
-def shared_datadir(request):
-    return pathlib.Path(request.fspath.dirname) / 'data'
+def shared_datadir(request, tmpdir):
+    original_shared_path = os.path.join(request.fspath.dirname, 'data')
+    temp_path = pathlib.Path(tmpdir.join('data'))
+    shutil.copytree(original_shared_path, str(temp_path))
+    return temp_path
 
 
 @pytest.fixture

--- a/pytest_datadir/plugin.py
+++ b/pytest_datadir/plugin.py
@@ -8,7 +8,7 @@ import pytest
 @pytest.fixture
 def shared_datadir(request, tmpdir):
     original_shared_path = os.path.join(request.fspath.dirname, 'data')
-    temp_path = pathlib.Path(tmpdir.join('data'))
+    temp_path = pathlib.Path(str(tmpdir.join('data')))
     shutil.copytree(original_shared_path, str(temp_path))
     return temp_path
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -9,7 +9,7 @@ def test_read_hello(datadir):
     assert contents == 'Hello, world!\n'
 
 
-def test_change_test_files(datadir, original_datadir):
+def test_change_test_files(datadir, original_datadir, shared_datadir, request):
     filename = datadir / 'hello.txt'
     with filename.open('w') as fp:
         fp.write('Modified text!\n')
@@ -20,6 +20,14 @@ def test_change_test_files(datadir, original_datadir):
 
     with filename.open() as fp:
         assert fp.read() == 'Modified text!\n'
+
+    shared_filename = shared_datadir/'over.txt'
+    with shared_filename.open('w') as fp:
+        fp.write('changed')
+    shared_original = os.path.join(request.fspath.dirname, 'data', 'over.txt')
+    with open(shared_original) as fp:
+        assert fp.read().strip() == '8000'
+
 
 
 def test_read_spam_from_other_dir(shared_datadir):


### PR DESCRIPTION
`shared_datadir` fixture was pointing to the original folder, so changes
in the files were not being rolled back after the test run.