### PR TITLE
Use pathlib2 on Python 2.7 instead of pathlib

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@ pytest-datadir
 ==============
 
 
+(unreleased)
+------------
+
+- Use ``pathlib2`` on Python 2.7: this is the proper backport of Python 3's standard
+  library.
+
 1.1.0 (2018-07-10)
 ------------------
 

--- a/pytest_datadir/plugin.py
+++ b/pytest_datadir/plugin.py
@@ -1,6 +1,11 @@
 import os
-import pathlib
 import shutil
+import sys
+
+if sys.version_info[0] == 2:
+    from pathlib2 import Path
+else:
+    from pathlib import Path
 
 import pytest
 
@@ -8,19 +13,19 @@ import pytest
 @pytest.fixture
 def shared_datadir(request, tmpdir):
     original_shared_path = os.path.join(request.fspath.dirname, 'data')
-    temp_path = pathlib.Path(str(tmpdir.join('data')))
+    temp_path = Path(str(tmpdir.join('data')))
     shutil.copytree(original_shared_path, str(temp_path))
     return temp_path
 
 
 @pytest.fixture
 def original_datadir(request):
-    return pathlib.Path(os.path.splitext(request.module.__file__)[0])
+    return Path(os.path.splitext(request.module.__file__)[0])
 
 
 @pytest.fixture
 def datadir(original_datadir, tmpdir):
-    result = pathlib.Path(str(tmpdir.join(original_datadir.stem)))
+    result = Path(str(tmpdir.join(original_datadir.stem)))
     if original_datadir.is_dir():
         shutil.copytree(str(original_datadir), str(result))
     else:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
 
     license='MIT',
     keywords='pytest test unittest directory file',
-    extras_require={':python_version<"3.4"': ['pathlib']},
+    extras_require={':python_version<"3.4"': ['pathlib2']},
     url='http://github.com/gabrielcnr/pytest-datadir',
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_pathlib.py
+++ b/tests/test_pathlib.py
@@ -1,0 +1,11 @@
+import sys
+import pytest
+
+@pytest.mark.skipif(sys.version_info[0] == 3, reason='Python 2 only')
+def test_correct_pathlib(datadir):
+    """
+    Dummy test that we are using the correct backport of Python 3's
+    standard pathlib in Python 2.
+    """
+    (datadir / 'foo').mkdir(parents=True, exist_ok=True)
+    (datadir / 'foo').mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The pathlib2 on PyPI is the actual backport of Python 3's standard
library. Using pathlib is confusing because it yields a different and
incompatible implementation with Python 3's.