### PR TITLE
Set module scope for original_datadir fixture

### DIFF
--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -33,7 +33,7 @@ def shared_datadir(request, tmpdir):
     return temp_path
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def original_datadir(request):
     return Path(os.path.splitext(request.module.__file__)[0])
 


### PR DESCRIPTION
This allows passing it to other module-scoped fixtures