### PR TITLE
Fix pytest-describe incompatibility

### DIFF
--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -42,7 +42,7 @@ def shared_datadir(request, tmp_path):
 
 @pytest.fixture
 def original_datadir(request):
-    return request.path.dirname / request.path.stem
+    return request.path.parent / request.path.stem
 
 
 @pytest.fixture

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -43,7 +43,7 @@ def shared_datadir(request, tmp_path):
 
 @pytest.fixture
 def original_datadir(request):
-    return Path(os.path.splitext(request.module.__file__)[0])
+    return request.path.dirname / request.path.stem
 
 
 @pytest.fixture

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import sys
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
Simplifies the `original_datadir` fixture called by `datadir` to use simpler `request.path` instead of `request.module.__file__`. This improves robustness and fixes incompatibility with [pytest-describe](https://github.com/pytest-dev/pytest-describe).

E.g., previously

```python
def describe_example():
    def test_example(datadir):
        assert True
```

caused the following error:

```bash
test setup failed
request = <SubRequest 'original_datadir' for <Function test_example>>

    @pytest.fixture
    def original_datadir(request):
>       return Path(os.path.splitext(request.module.__file__)[0])
E       AttributeError: module 'describe_example' has no attribute '__file__'. Did you mean: '__name__'?
```
Due to the `module` object for `describe_example` not having a valid `__file__` attribute because it is a function.

Fixes #86 