### PR TITLE
Implement fixture that does lazy/on-demand copy of the files

### DIFF
--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -55,3 +55,16 @@ def datadir(original_datadir, tmp_path):
     else:
         result.mkdir()
     return result
+
+
+@pytest.fixture
+def lazy_datadir(original_datadir, tmp_path):
+    result = tmp_path / original_datadir.stem
+    if not result.is_dir():
+        if original_datadir.is_dir():
+            shutil.copytree(
+                _win32_longpath(str(original_datadir)), _win32_longpath(str(result))
+            )
+        else:
+            result.mkdir()
+    return result

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,7 +1,11 @@
 import os
+import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+
+from pytest_datadir.plugin import _win32_longpath
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -21,7 +25,7 @@ def create_long_file_path():
         os.chdir(old_cwd)
 
 
-def test_read_hello(datadir):
+def test_read_hello(datadir, lazy_datadir):
     assert set(os.listdir(str(datadir))) == {
         "local_directory",
         "hello.txt",
@@ -31,19 +35,27 @@ def test_read_hello(datadir):
     with (datadir / "hello.txt").open() as fp:
         contents = fp.read()
     assert contents == "Hello, world!\n"
+    with (lazy_datadir / "hello.txt").open() as fp:
+        contents = fp.read()
+    assert contents == "Hello, world!\n"
 
 
-def test_change_test_files(datadir, original_datadir, shared_datadir, request):
+def test_change_test_files(datadir, lazy_datadir, original_datadir, shared_datadir, request):
     filename = datadir / "hello.txt"
     with filename.open("w") as fp:
         fp.write("Modified text!\n")
+    with filename.open() as fp:
+        assert fp.read() == "Modified text!\n"
+
+    lazy_filename = lazy_datadir / "hello.txt"
+    with lazy_filename.open("w") as fp:
+        fp.write("Modified text again!\n")
+    with lazy_filename.open() as fp:
+        assert fp.read() == "Modified text again!\n"
 
     original_filename = original_datadir / "hello.txt"
     with original_filename.open() as fp:
         assert fp.read() == "Hello, world!\n"
-
-    with filename.open() as fp:
-        assert fp.read() == "Modified text!\n"
 
     shared_filename = shared_datadir / "over.txt"
     with shared_filename.open("w") as fp:
@@ -60,24 +72,27 @@ def test_read_spam_from_other_dir(shared_datadir):
     assert contents == "eggs\n"
 
 
-def test_file_override(shared_datadir, datadir):
+def test_file_override(shared_datadir, datadir, lazy_datadir):
     """The same file is in the module dir and global data.
     Shared files are kept in a different temp directory"""
     shared_filepath = shared_datadir / "over.txt"
     private_filepath = datadir / "over.txt"
+    lazy_filepath = lazy_datadir / "over.txt"
     assert shared_filepath.is_file()
     assert private_filepath.is_file()
     assert shared_filepath != private_filepath
+    assert lazy_filepath.is_file()
+    assert shared_filepath != lazy_filepath
 
 
-def test_local_directory(datadir):
-    directory = datadir / "local_directory"
-    assert directory.is_dir()
-    filename = directory / "file.txt"
-    assert filename.is_file()
-    with filename.open() as fp:
-        contents = fp.read()
-    assert contents.strip() == "local contents"
+def test_local_directory(datadir, lazy_datadir):
+    for directory in [datadir / "local_directory", lazy_datadir / "local_directory"]:
+        assert directory.is_dir()
+        filename = directory / "file.txt"
+        assert filename.is_file()
+        with filename.open() as fp:
+            contents = fp.read()
+        assert contents.strip() == "local contents"
 
 
 def test_shared_directory(shared_datadir):
@@ -87,3 +102,38 @@ def test_shared_directory(shared_datadir):
     with filename.open() as fp:
         contents = fp.read()
     assert contents.strip() == "global contents"
+
+
+@pytest.fixture
+def mock_copytree():
+    with patch('shutil.copytree') as mock:
+        yield mock
+
+
+@pytest.fixture
+def eager_create_datadir(original_datadir, tmp_path):
+    result = tmp_path / original_datadir.stem
+    print(f"vfg2: Lazy datadir: {result}")
+    if not result.is_dir():
+        print("vfg2: Creating lazy datadir...")
+        if original_datadir.is_dir():
+            print("vfg2: Copying original datadir...")
+            print(f"vfg2: is this a mock? {shutil.copytree}")
+            shutil.copytree(
+                _win32_longpath(str(original_datadir)), _win32_longpath(str(result))
+            )
+        else:
+            result.mkdir()
+
+
+def test_lazy_copy_happens_once(eager_create_datadir, mock_copytree, lazy_datadir):
+        # Access the same file multiple times
+        for _ in range(3):
+            _ = lazy_datadir / "hello.txt"
+            
+        # Access the same directory multiple times    
+        for _ in range(3):
+            _ = lazy_datadir / "local_directory"
+        
+        # copytree only called once by eager_create_datadir, not by lazy_datadir
+        assert mock_copytree.call_count == 0

--- a/tests/test_nonexistent.py
+++ b/tests/test_nonexistent.py
@@ -1,2 +1,5 @@
 def test_missing_data_dir_starts_empty(datadir):
     assert list(datadir.iterdir()) == []
+
+def test_missing_lazy_data_dir_starts_empty(lazy_datadir):
+    assert list(lazy_datadir.iterdir()) == []


### PR DESCRIPTION
This PR creates a new `lazy_datadir` fixture which is identical to `datadir` except that it includes the "lazy" copy behavior discussed in https://github.com/gabrielcnr/pytest-datadir/issues/95, where `shutil.copytree` is only called once, rather than every time the fixture is invoked.

I considered the `dataclass` approach suggested [here](https://github.com/gabrielcnr/pytest-datadir/issues/95#issue-3063408243), but I believe this implementation achieves the same goal of lazy copying, without the need for a new class. If there's some benefit about that approach that is missing from this PR, let me know. It shouldn't be too difficult to switch to that approach while keeping my testing updates more or less the same.

Since the change does not update any existing fixture, it should be backwards compatible. Arguably, the change could be made directly in `datadir`, but that may cause backwards compatibility problems.