### PR TITLE
Fix `LazyDataDir.joinpath` type checking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,15 @@
 pytest-datadir
 ==============
 
-1.7.2
+UNRELEASED
 ----------
+
+*UNRELEASED*
+
+- Fix ``LazyDataDir.joinpath`` typing to also support ``Path`` objects as the right-hand side parameter.
+
+1.7.2
+-----
 
 *2025-06-06*
 

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -3,6 +3,7 @@ import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Union
 
 import pytest
 
@@ -71,7 +72,7 @@ class LazyDataDir:
     original_datadir: Path
     tmp_path: Path
 
-    def joinpath(self, other: Path | str) -> Path:
+    def joinpath(self, other: Union[Path, str]) -> Path:
         """
         Return `other` joined with the temporary directory.
 
@@ -95,7 +96,7 @@ class LazyDataDir:
                 )
         return target
 
-    def __truediv__(self, other: Path | str) -> Path:
+    def __truediv__(self, other: Union[Path, str]) -> Path:
         return self.joinpath(other)
 
 

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -71,7 +71,7 @@ class LazyDataDir:
     original_datadir: Path
     tmp_path: Path
 
-    def joinpath(self, other: str) -> Path:
+    def joinpath(self, other: Path | str) -> Path:
         """
         Return `other` joined with the temporary directory.
 

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -95,7 +95,7 @@ class LazyDataDir:
                 )
         return target
 
-    def __truediv__(self, other: str) -> Path:
+    def __truediv__(self, other: Path | str) -> Path:
         return self.joinpath(other)
 
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -106,7 +106,7 @@ def test_lazy_copy(lazy_datadir: LazyDataDir) -> None:
 
     # Accessing the same file multiple times does not copy the file again.
     hello.write_text("Hello world, hello world.")
-    hello = lazy_datadir / "hello.txt"
+    hello = lazy_datadir / Path("hello.txt")
     assert hello.read_text() == "Hello world, hello world."
 
     # Lazy copy data directory.


### PR DESCRIPTION
`Path.joinpath` and the `/` operator also support `Path` objects as the right-hand side parameter.