### PR TITLE
Add lazy version of shared_datadir

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 
 *UNRELEASED*
 
+- New ``lazy_shared_datadir`` fixture, which brings the same lazy functionality as ``lazy_datadir`` for the *shared* directory.
 - Fix ``LazyDataDir.joinpath`` typing to also support ``Path`` objects as the right-hand side parameter.
 
 1.7.2

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ def test_read_module(lazy_datadir):
 
 Unlike `datadir`, `lazy_datadir` is an object that only implements `joinpath` and `/` operations. While not fully backward-compatible with `datadir`, most tests can switch to `lazy_datadir` without modifications.
 
+### lazy_shared_datadir
+
+`lazy_shared_datadir` is similar to `lazy_datadir`, but applied to the shared data directory `shared_datadir`.
+That is, instead of copying all files in `shared_datadir`, files are only copied as necessary when accessed via `joinpath` or the `/` operator.
+This allows for a shared data directory to be pulled from lazily in the same manner as `lazy_datadir`.
+
+```python
+def test_read_global(lazy_shared_datadir):
+    contents = (lazy_shared_datadir / "hello.txt").read_text()
+    assert contents == "Hello World!\n"
+```
+
 # License
 
 MIT.

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -116,6 +116,7 @@ def lazy_datadir(original_datadir: Path, tmp_path: Path) -> LazyDataDir:
     """
     return LazyDataDir(original_datadir, tmp_path)
 
+
 @pytest.fixture
 def lazy_shared_datadir(request: pytest.FixtureRequest, tmp_path: Path) -> LazyDataDir:
     """

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -115,3 +115,22 @@ def lazy_datadir(original_datadir: Path, tmp_path: Path) -> LazyDataDir:
         tmp_path: Pytest's built-in fixture providing a temporary directory path.
     """
     return LazyDataDir(original_datadir, tmp_path)
+
+@pytest.fixture
+def lazy_shared_datadir(request: pytest.FixtureRequest, tmp_path: Path) -> LazyDataDir:
+    """
+    Return a lazy version of the shared data directory.
+
+    Here, "lazy" means that the temporary directory is initially created empty.
+
+    Files and directories are then copied from the data directory only when first
+    accessed via the ``joinpath`` method or the ``/`` operator.
+
+    Args:
+        request: The Pytest fixture request object.
+        tmp_path: Pytest's built-in fixture providing a temporary directory path.
+    """
+    original_shared_path = Path(os.path.join(request.fspath.dirname, "data"))
+    temp_path = tmp_path / "data"
+
+    return LazyDataDir(original_shared_path, temp_path)

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
-from os import mkdir
 from pathlib import Path
 from typing import Union
 

--- a/src/pytest_datadir/plugin.py
+++ b/src/pytest_datadir/plugin.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 from dataclasses import dataclass
+from os import mkdir
 from pathlib import Path
 from typing import Union
 
@@ -133,5 +134,6 @@ def lazy_shared_datadir(request: pytest.FixtureRequest, tmp_path: Path) -> LazyD
     """
     original_shared_path = Path(os.path.join(request.fspath.dirname, "data"))
     temp_path = tmp_path / "data"
+    temp_path.mkdir(parents=True, exist_ok=False)
 
     return LazyDataDir(original_shared_path, temp_path)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -140,3 +140,52 @@ def test_lazy_copy_sub_directory(lazy_datadir: LazyDataDir) -> None:
         "local_directory",
     }
     assert fn.read_text() == "local contents"
+
+
+def test_shared_lazy_copy(lazy_shared_datadir: LazyDataDir, tmp_path: Path) -> None:
+    # The temporary directory starts containing only an empty data directory.
+    assert {x.name for x in tmp_path.iterdir()} == {"data"}
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == set()
+
+    # Lazy copy file.
+    spam = lazy_shared_datadir / "spam.txt"
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == {"spam.txt"}
+    assert spam.read_text() == "eggs\n"
+
+    # Accessing the same file multiple times does not copy the file again.
+    spam.write_text("eggs and ham\n")
+    spam = lazy_shared_datadir / Path("spam.txt")
+    assert spam.read_text() == "eggs and ham\n"
+
+    # Lazy copy data directory.
+    shared_dir = lazy_shared_datadir / "shared_directory"
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == {
+        "spam.txt",
+        "shared_directory",
+    }
+    assert shared_dir.is_dir() is True
+    assert shared_dir.joinpath("file.txt").read_text() == "global contents"
+
+    # It is OK to request a file that does not exist in the data directory.
+    fn = lazy_shared_datadir / "new-file.txt"
+    assert fn.exists() is False
+    fn.write_text("new contents")
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == {
+        "spam.txt",
+        "shared_directory",
+        "new-file.txt",
+    }
+
+
+def test_shared_lazy_copy_sub_directory(lazy_shared_datadir: LazyDataDir, tmp_path: Path) -> None:
+    """Copy via file by using a sub-directory (#99)."""
+    # The temporary directory starts containing only an empty data directory.
+    assert {x.name for x in tmp_path.iterdir()} == {"data"}
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == set()
+
+    # Lazy copy file in a sub-directory.
+    fn = lazy_shared_datadir / "shared_directory/file.txt"
+    assert {x.name for x in lazy_shared_datadir.tmp_path.iterdir()} == {
+        "shared_directory",
+    }
+    assert fn.read_text() == "global contents"

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -177,7 +177,9 @@ def test_shared_lazy_copy(lazy_shared_datadir: LazyDataDir, tmp_path: Path) -> N
     }
 
 
-def test_shared_lazy_copy_sub_directory(lazy_shared_datadir: LazyDataDir, tmp_path: Path) -> None:
+def test_shared_lazy_copy_sub_directory(
+    lazy_shared_datadir: LazyDataDir, tmp_path: Path
+) -> None:
     """Copy via file by using a sub-directory (#99)."""
     # The temporary directory starts containing only an empty data directory.
     assert {x.name for x in tmp_path.iterdir()} == {"data"}


### PR DESCRIPTION
A quick-and-dirty implementation of the lazy datadir that uses a shared data directory mimicking `shared_datadir`. 

This is very useful for when there are a lot of data files and organizing them for every single test / test file instead of using a single shared data directory is very cumbersome, but copying all of the files each time `shared_datadir` is used induces lots of excessive copying/file usage.